### PR TITLE
Feature/event/parser2

### DIFF
--- a/src/event/error.rs
+++ b/src/event/error.rs
@@ -1,0 +1,93 @@
+/*
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use std::{
+    fmt::{self, Debug},
+    io,
+    str::Utf8Error,
+};
+
+use crate::{reader::ReaderError, scanner::error::ScanError};
+
+pub type ParseResult<T> = std::result::Result<T, ParseError>;
+
+#[derive(Debug)]
+pub enum ParseError
+{
+    CorruptStream,
+    DuplicateVersion,
+    DuplicateTagDirective,
+    UndefinedTag,
+    MissingDocumentStart,
+    MissingBlockEntry,
+    MissingNode,
+    MissingKey,
+    MissingFlowSequenceEntryOrEnd,
+    MissingFlowMappingEntryOrEnd,
+
+    Scanner(ScanError),
+    UTF8(Utf8Error),
+    IO(io::Error),
+
+    UnexpectedEOF,
+}
+
+impl From<ScanError> for ParseError
+{
+    fn from(e: ScanError) -> Self
+    {
+        Self::Scanner(e)
+    }
+}
+
+impl From<ReaderError> for ParseError
+{
+    fn from(e: ReaderError) -> Self
+    {
+        match e
+        {
+            ReaderError::UTF8(e) => Self::UTF8(e),
+            ReaderError::IO(e) => Self::IO(e),
+            ReaderError::Scanner(e) => Self::Scanner(e),
+        }
+    }
+}
+
+impl PartialEq for ParseError
+{
+    fn eq(&self, other: &Self) -> bool
+    {
+        match (self, other)
+        {
+            (Self::Scanner(s), Self::Scanner(o)) => s == o,
+            (Self::UTF8(s), Self::UTF8(o)) => s == o,
+            (Self::IO(s), Self::IO(o)) => s.kind() == o.kind(),
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+
+impl fmt::Display for ParseError
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
+    {
+        Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for ParseError
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)>
+    {
+        match self
+        {
+            Self::Scanner(e) => Some(e),
+            Self::UTF8(e) => Some(e),
+            Self::IO(e) => Some(e),
+            _ => None,
+        }
+    }
+}

--- a/src/event/macros.rs
+++ b/src/event/macros.rs
@@ -1,0 +1,299 @@
+/*
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/// Peek the head of the .queue, returning its start and end
+/// byte and a marker representing the underlying Token, in
+/// a three item tuple (.start, .end, .marker)
+///
+/// Modifiers
+///     ~  .queue := return .marker
+///     @~ .queue := return Option<.marker> (no error)
+///
+/// Variants
+///     /1 .queue
+macro_rules! peek {
+    ($queue:expr) => {
+        $queue
+            .peek()
+            .map_err(Into::into)
+            .and_then(|maybe| maybe.ok_or($crate::event::error::ParseError::UnexpectedEOF))
+            .map(|entry| (entry.read_at(), entry.read_at(), entry.marker()))
+    };
+    (~ $queue:expr) => {
+        $queue
+            .peek()
+            .map_err(Into::into)
+            .and_then(|maybe| maybe.ok_or($crate::event::error::ParseError::UnexpectedEOF))
+            .map(|entry| entry.marker())
+    };
+    (@ ~ $queue:expr) => {
+        $queue
+            .peek()
+            .map_err($crate::event::error::ParseError::from)
+            .map(|maybe| maybe.map(|entry| entry.marker()))
+    };
+}
+
+/// Pop the head of the .queue, returning the entry, or an
+/// error if the queue was empty. Typically
+/// used in combination with peek!
+///
+/// Variants
+///     /1 .queue
+macro_rules! pop {
+    ($queue:expr) => {
+        $queue
+            .pop()
+            .map_err(Into::into)
+            .and_then(|maybe| maybe.ok_or($crate::event::error::ParseError::UnexpectedEOF))
+    };
+}
+
+/// ```text
+/// Manipulate the given state .machine (or .parser),
+/// pushing / popping states in the stack and modifying the
+/// current top state
+///
+/// Variants
+///     /1 .machine, $op .state
+///     /2 .parser, $op .state *[, $op .state ]
+///
+///     $op :=
+///         | -> (change top state)
+///         | >> (push state to stack)
+///         | |> (change top state, add old top to stack)
+///         | << (pop state from stack to top)
+/// ```
+macro_rules! state {
+    (~$parser:expr, $( $op:tt $state:expr ),+) => {
+        $( state!($parser.state, $op $state); )+
+    };
+
+    ($machine:expr, -> $state:expr) => {
+        *$machine.top_mut() = $state
+    };
+    ($machine:expr, >> $state:expr) => {
+        $machine.push($state)
+    };
+    ($machine:expr, |> $state:expr) => {
+        $machine.push_top($state)
+    };
+    ($machine:expr, << $_:expr) => {
+        $machine.pop()
+    };
+}
+
+/// ```text
+/// Consume an entry of $kind from the .queue, returning its
+/// (start, end, context), or an error. Note that the exact
+/// nature of context varies.
+///
+/// Variants
+///     /1 .queue, $kind
+///
+///     $kind :=
+///         | StreamStart
+///         | StreamEnd
+///         | VersionDirective
+///         | TagDirective
+///         | Alias
+///         | Anchor
+///         | Tag
+///         | Scalar
+///         | FlowSequenceStart
+///         | FlowMappingStart
+///         | BlockSequenceStart
+///         | BlockMappingStart
+/// ```
+macro_rules! consume {
+    ($queue:expr, $kind:tt) => {{
+        #[allow(unused_imports)]
+        use $crate::{token::Token::*, scanner::entry::MaybeToken, event::types::{Event, EventData, VersionDirective, Scalar}};
+
+        #[allow(clippy::collapsible_match)]
+        pop!($queue).map(|entry| consume!(@wrap entry, $kind))
+    }};
+
+    (@wrap $entry:expr, Scalar) => {{
+        let end = $entry.read_at();
+
+        match $entry.wrap {
+            MaybeToken::Token(token) => match token {
+                Scalar(data, style) => (end, end, Scalar::Eager { data, style }),
+                _ => unreachable!(),
+            },
+            MaybeToken::Deferred(lazy) => (end, end, Scalar::Lazy { data: Box::new(lazy) })
+        }
+    }};
+    (@wrap $entry:expr, $kind:tt) => {{
+        let end = $entry.read_at();
+
+        match $entry.wrap {
+            MaybeToken::Token(token) => consume!(@entry $kind => end, end, token),
+            _ => unreachable!(),
+        }
+    }};
+
+    (@entry StreamStart => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            StreamStart(encoding) => ($start, $end, encoding),
+            _ => unreachable!(),
+        }
+    };
+    (@entry StreamEnd => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            StreamEnd => ($start, $end, ()),
+            _ => unreachable!(),
+        }
+    };
+    (@entry VersionDirective => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            VersionDirective(major, minor) => ($start, $end, VersionDirective { major, minor }),
+            _ => unreachable!(),
+        }
+    };
+    (@entry TagDirective => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            TagDirective(handle, prefix) => ($start, $end, (handle, prefix)),
+            _ => unreachable!(),
+        }
+    };
+    (@entry Alias => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            Alias(name) => ($start, $end, name),
+            _ => unreachable!(),
+        }
+    };
+    (@entry Anchor => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            Anchor(name) => ($start, $end, name),
+            _ => unreachable!(),
+        }
+    };
+    (@entry Tag => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            Tag(handle, suffix) => ($start, $end, (handle, suffix)),
+            _ => unreachable!(),
+        }
+    };
+    (@entry FlowSequenceStart => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            FlowSequenceStart => ($start, $end, ()),
+            _ => unreachable!(),
+        }
+    };
+    (@entry FlowMappingStart => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            FlowMappingStart => ($start, $end, ()),
+            _ => unreachable!(),
+        }
+    };
+    (@entry BlockSequenceStart => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            BlockSequenceStart => ($start, $end, ()),
+            _ => unreachable!(),
+        }
+    };
+    (@entry BlockMappingStart => $start:expr, $end:expr, $token:expr) => {
+        match $token {
+            BlockMappingStart => ($start, $end, ()),
+            _ => unreachable!(),
+        }
+    };
+}
+
+/// ```text
+/// Generate a new event of $kind from the given .context,
+/// or consume it from the provided .queue.
+///
+/// Variants
+///     /1 @event $kind => .context
+///     /2 @consume $kind => .queue
+///
+///     $kind :=
+///         | StreamStart
+///         | StreamEnd
+///         | DocumentStart
+///         | DocumentEnd
+///         | Alias
+///         | Scalar
+///         | BlockSequenceStart
+///         | BlockMappingStart
+///         | FlowSequenceStart
+///         | FlowMappingStart
+///         | SequenceEnd
+///         | MappingEnd
+/// ```
+macro_rules! initEvent {
+    (@consume $kind:tt => $queue:expr) => {{
+        #[allow(unused_imports)]
+        use $crate::{event::types::{self, EventData}};
+
+        consume!($queue, $kind).map(|context| initEvent!(@event $kind => context))
+    }};
+
+    (@event StreamStart => $context:expr) => {{
+        let (start, end, encoding) = $context;
+
+        Event::new(start, end, EventData::StreamStart(types::StreamStart { encoding }))
+    }};
+    (@event StreamEnd => $context:expr) => {{
+        let (start, end, ()) = $context;
+
+        Event::new(start, end, EventData::StreamEnd)
+    }};
+    (@event DocumentStart => $context:expr) => {{
+        let (start, end, (version, tags, implicit)) = $context;
+        let directives = types::Directives { version, tags };
+
+        Event::new(start, end, EventData::DocumentStart(types::DocumentStart { directives, implicit }))
+    }};
+    (@event DocumentEnd => $context:expr) => {{
+        let (start, end, implicit) = $context;
+
+        Event::new(start, end, EventData::DocumentEnd(types::DocumentEnd { implicit }))
+    }};
+    (@event SequenceEnd => $context:expr) => {{
+        let (start, end, _) = $context;
+
+        Event::new(start, end, EventData::SequenceEnd)
+    }};
+    (@event MappingEnd => $context:expr) => {{
+        let (start, end, _) = $context;
+
+        Event::new(start, end, EventData::MappingEnd)
+    }};
+    (@event Alias => $context:expr) => {{
+        let (start, end, name) = $context;
+
+        Event::new(start, end, EventData::Alias(types::Alias { name }))
+    }};
+    (@event FlowSequenceStart => $context:expr) => {{
+        let (start, end, (anchor, tag, kind)) = $context;
+
+        Event::new(start, end, EventData::SequenceStart(types::Node { anchor, tag, content: types::Sequence, kind }))
+    }};
+    (@event FlowMappingStart => $context:expr) => {{
+        let (start, end, (anchor, tag, kind)) = $context;
+
+        Event::new(start, end, EventData::MappingStart(types::Node { anchor, tag, content: types::Mapping, kind }))
+    }};
+    (@event BlockSequenceStart => $context:expr) => {{
+        let (start, end, (anchor, tag, kind)) = $context;
+
+        Event::new(start, end, EventData::SequenceStart(types::Node { anchor, tag, content: types::Sequence, kind }))
+    }};
+    (@event BlockMappingStart => $context:expr) => {{
+        let (start, end, (anchor, tag, kind)) = $context;
+
+        Event::new(start, end, EventData::MappingStart(types::Node { anchor, tag, content: types::Mapping, kind }))
+    }};
+    (@event Scalar => $context:expr) => {{
+        let (start, end, (anchor, tag, kind, content)) = $context;
+
+        Event::new(start, end, EventData::Scalar(types::Node { anchor, tag, content, kind }))
+    }};
+}

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1307,3 +1307,45 @@ const EXPLICIT: bool = false;
 const BLOCK_CONTEXT: bool = true;
 const NO_ANCHOR: Option<Slice<'static>> = None;
 const NO_TAG: Option<(Slice<'static>, Slice<'static>)> = None;
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+    use crate::reader::borrow::BorrowReader;
+
+    #[macro_use]
+    mod macros;
+
+    struct ParseIter<'de>
+    {
+        tokens: Tokens<'de, BorrowReader<'de>>,
+        parser: Parser,
+    }
+
+    impl<'de> ParseIter<'de>
+    {
+        fn new(tokens: Tokens<'de, BorrowReader<'de>>) -> Self
+        {
+            Self {
+                tokens,
+                parser: Parser::new(),
+            }
+        }
+
+        fn next_event(&mut self) -> Result<Option<Event<'de>>>
+        {
+            self.parser.get_next_event(&mut self.tokens)
+        }
+    }
+
+    impl<'de> Iterator for ParseIter<'de>
+    {
+        type Item = Result<Event<'de>>;
+
+        fn next(&mut self) -> Option<Self::Item>
+        {
+            self.next_event().transpose()
+        }
+    }
+}

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -4,6 +4,97 @@
  * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+//! This module exposes the [Parser] struct and related
+//! types. The Parser takes a sequence of [Token]s produced
+//! by a generic [Read] interface, and converts them
+//! into a series of [Event]s. These events are the core of
+//! higher level functionality exposed by this library.
+//!
+//! They (and the Parser) are also the lowest level public
+//! API, as [Read] is a sealed trait. Typically, you
+//! shouldn't need to interact with anything in this module
+//! directly, but if you want to build specialized code
+//! which directly consumes an event stream, e.g to avoid
+//! paying for node collation / storage, scalar type
+//! resolution, etc.
+//!
+//! If you are going to use this module, you should read
+//! the following to get an understanding of how [Read]
+//! impls, the [Parser], and [Event]s work together.
+//!
+//! ## Invoking the Parser
+//!
+//! Each [Parser] must be passed a [PeekReader<'de, T>]
+//! where `T: Read`. PeekReader has a blanket [From]
+//! impl for any type implementing [Read]. Once passed to a
+//! [Parser], _it is a logic error to pass that PeekReader
+//! to a different [Parser]_. The outcome is not specified,
+//! but will likely either be garbage or and error.
+//!
+//! The two interesting methods on a [Parser] are:
+//!
+//! 1. [next_event](Parser.next_event)
+//! 2. [into_iter](Parser.into_iter)
+//!
+//! Both take one argument, the [PeekReader] associated
+//! with this [Parser]. The first, `next_event` returns
+//! the next [Event] (naturally), while the second,
+//! `into_iter`, returns an interface that implements
+//! [Iterator], allowing one to hook into that entire
+//! ecosystem.
+//!
+//! ## Understanding Events
+//!
+//! Each event produced represents an important semantic
+//! change in the underlying YAML byte stream. Broadly,
+//! these can be categorized into three spaces:
+//!
+//! 1. Virtual / Marker
+//!     - [StreamStart](Event::StreamStart),
+//!     - [StreamEnd](Event::StreamEnd),
+//!     - [DocumentStart](Event::DocumentStart),
+//!     - [DocumentEnd](Event::DocumentEnd),
+//!
+//! 2. Nesting change (+-)
+//!     - [MappingStart](Event::MappingStart),
+//!     - [MappingEnd](Event::MappingEnd),
+//!     - [SequenceStart](Event::SequenceStart),
+//!     - [SequenceEnd](Event::SequenceEnd),
+//!
+//! 3. Data / Alias
+//!     - [Scalar](Event::Scalar),
+//!     - [Alias](Event::Alias),
+//!
+//! Together, these are used to produce the following
+//! productions:
+//!
+//! ```text
+//! stream          := StreamStart document+ StreamEnd
+//! document        := DocumentStart content? DocumentEnd
+//! content         := Scalar | collection
+//! collection      := sequence | mapping
+//! sequence        := SequenceStart node* SequenceEnd
+//! mapping         := MappingStart (node node)* MappingEnd
+//! node            := Alias | content
+//!
+//! ?               => 0 or 1 of prefix
+//! *               => 0 or more of prefix
+//! +               => 1 or more of prefix
+//! ()              => production grouping
+//! |               => production logical OR
+//! ```
+//!
+//! In addition to the various [Event] types, every [Node]
+//! also provides a hint as to its placement in the stream
+//! via its [NodeKind]. Together, these should allow users
+//! to maintain relatively little external state regarding
+//! the [Event] stream, beyond anything they wish to
+//! collect from the stream.
+//!
+//! [Token]: enum@crate::token::Token
+//! [Read]: trait@crate::reader::Read
+//! [Node]: struct@crate::event::types::Node
+
 use std::array::IntoIter as ArrayIter;
 
 use crate::{

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -3,3 +3,5 @@
  * Mozilla Public License, v. 2.0. If a copy of the MPL
  * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+
+mod state;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -7,3 +7,4 @@
 mod state;
 
 pub mod error;
+pub mod types;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -7,8 +7,8 @@
 use crate::{
     event::{
         error::ParseResult as Result,
-        state::{State, StateMachine},
-        types::{Directives, Event},
+        state::{Flags, State, StateMachine},
+        types::{Directives, Event, NodeKind},
     },
     reader::{PeekReader, Read},
 };
@@ -123,25 +123,223 @@ impl Parser
     {
         match *self.state.top()
         {
-            State::StreamStart => todo!(),
-            State::DocumentStart(opts) => todo!(),
-            State::DocumentContent => todo!(),
-            State::DocumentEnd => todo!(),
-            State::BlockNode => todo!(),
-            State::FlowNode => todo!(),
-            State::BlockSequenceEntry(opts) => todo!(),
-            State::BlockMappingKey(opts) => todo!(),
-            State::BlockMappingValue => todo!(),
-            State::FlowSequenceEntry(opts) => todo!(),
-            State::FlowSequenceMappingKey => todo!(),
-            State::FlowSequenceMappingValue => todo!(),
-            State::FlowSequenceMappingEnd => todo!(),
-            State::FlowMappingKey(opts) => todo!(),
-            State::FlowMappingValue(opts) => todo!(),
+            State::StreamStart => self.stream_start(tokens),
+            State::DocumentStart(opts) => self.document_start(tokens, opts),
+            State::DocumentContent => self.explicit_document_content(tokens),
+            State::DocumentEnd => self.document_end(tokens),
+            State::BlockNode => self.node(tokens, BLOCK_CONTEXT, NodeKind::Root),
+            State::FlowNode => self.node(tokens, !BLOCK_CONTEXT, NodeKind::Root),
+            State::BlockSequenceEntry(opts) => self.block_sequence_entry(tokens, opts),
+            State::BlockMappingKey(opts) => self.block_mapping_key(tokens, opts),
+            State::BlockMappingValue => self.block_mapping_value(tokens),
+            State::FlowSequenceEntry(opts) => self.flow_sequence_entry(tokens, opts),
+            State::FlowSequenceMappingKey => self.flow_sequence_entry_mapping_key(tokens),
+            State::FlowSequenceMappingValue => self.flow_sequence_entry_mapping_value(tokens),
+            State::FlowSequenceMappingEnd => self.flow_sequence_entry_mapping_end(tokens),
+            State::FlowMappingKey(opts) => self.flow_mapping_key(tokens, opts),
+            State::FlowMappingValue(opts) => self.flow_mapping_value(tokens, opts),
 
             // State machine terminus, no more events will be produced by this parser
-            State::StreamEnd => todo!(),
+            State::StreamEnd => self.stream_end(tokens),
         }
+    }
+
+    /// Start of token stream, ensure the underlying Read
+    /// stream hasn't been tampered with, and return the
+    /// associated Event
+    fn stream_start<'de, T>(&mut self, tokens: &mut Tokens<'de, T>) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// End of token stream, set ourself to done and produce
+    /// the associated Event, if we haven't already
+    fn stream_end<'de, T>(&mut self, tokens: &mut Tokens<'de, T>) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Start of a new document, process any directives,
+    /// determine if it's explicit and prime the state
+    /// machine accordingly, returning the associated
+    /// Event if appropriate
+    fn document_start<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+        opts: Flags,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// End of document, determine if its explicit, and
+    /// return the associated Event
+    fn document_end<'de, T>(&mut self, tokens: &mut Tokens<'de, T>) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Handle an explicit, maybe empty document returning
+    /// the root node [Event] if appropriate, or nothing
+    /// if the document is empty.
+    fn explicit_document_content<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Block context sequence entry, return the associated
+    /// node or sequence end [Event]
+    fn block_sequence_entry<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+        opts: Flags,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Block context mapping key, return the appropriate
+    /// node or mapping end [Event], pushing a mapping value
+    /// state to the stack in the former case
+    fn block_mapping_key<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+        opts: Flags,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Block context mapping value, return the appropriate
+    /// node or mapping end [Event], pushing a mapping key
+    /// state to the stack in the former case
+    fn block_mapping_value<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Flow context sequence entry, return the associated
+    /// node or sequence end [Event]
+    fn flow_sequence_entry<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+        opts: Flags,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Flow mapping key with parent flow sequence, return
+    /// the associated node [Event] and prep the tight state
+    /// loop for flow_sequence->flow_mapping token sequences
+    fn flow_sequence_entry_mapping_key<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Flow mapping value with parent flow sequence, return
+    /// the associated node [Event] and push a
+    /// FlowSequenceMappingEnd to the state stack.
+    ///
+    /// Note it is an invariant of this function that it
+    /// must *always* push the above state to the stack
+    /// -- excluding in error cases.
+    fn flow_sequence_entry_mapping_value<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Clean up after a flow_sequence->flow_mapping state
+    /// loop, returning the appropriate mapping end [Event]
+    fn flow_sequence_entry_mapping_end<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Flow context mapping key, return the appropriate
+    /// node or mapping end [Event], pushing a mapping value
+    /// state to the stack in the former case
+    fn flow_mapping_key<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+        opts: Flags,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Flow context mapping value, return the appropriate
+    /// node or mapping end [Event]
+    fn flow_mapping_value<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+        opts: Flags,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Produce a node or alias [Event]
+    fn node<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+        block: bool,
+        kind: NodeKind,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        todo!()
+    }
+
+    /// Produce an empty scalar node [Event], always returns
+    /// Ok, the Result is mostly for compose-ability
+    fn empty_scalar(&mut self, mark: usize, kind: NodeKind) -> Result<Event<'static>>
+    {
+        todo!()
     }
 }
 
@@ -175,3 +373,5 @@ where
         self.parser.next_event(self.reader)
     }
 }
+
+const BLOCK_CONTEXT: bool = true;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -4,6 +4,15 @@
  * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+use crate::{
+    event::{
+        error::ParseResult as Result,
+        state::{State, StateMachine},
+        types::{Directives, Event},
+    },
+    reader::{PeekReader, Read},
+};
+
 #[macro_use]
 mod macros;
 
@@ -11,3 +20,158 @@ mod state;
 
 pub mod error;
 pub mod types;
+
+type Tokens<'de, T> = PeekReader<'de, T>;
+
+/// The [Parser] provides an API for translating any
+/// [Token] [Read] stream into higher level [Event]s.
+///
+/// The two primary methods of of interest on this
+/// struct are:
+///
+/// 1. [next_event](#method.next_event)
+/// 2. [into_iter](#method.into_iter)
+///
+/// The first provides an interface for retrieving the
+/// next [Event] from the given [Read]er, while the
+/// latter provides an [Iterator] based interface to
+/// retrieve [Event]s from, reusing the provided [Read]er.
+///
+/// A Parser can iteratively consume an entire [Token]
+/// stream ending when `Token::StreamEnd` is found, after
+/// which the Parser considers the stream finished and
+/// always returns None.
+///
+/// [Token]: enum@crate::token::Token
+/// [Read]: trait@crate::reader::Read
+#[derive(Debug, Clone)]
+pub struct Parser
+{
+    state: StateMachine,
+
+    directives: Directives<'static>,
+    done:       bool,
+}
+
+impl Parser
+{
+    /// Instantiate a new [Parser], ready for a new token
+    /// stream.
+    pub fn new() -> Self
+    {
+        Self {
+            state:      StateMachine::default(),
+            directives: Default::default(),
+            done:       false,
+        }
+    }
+
+    /// Fetch the next [Event] from the provided .tokens
+    /// stream.
+    ///
+    /// Note that once you call this method, the associated
+    /// .tokens is "bound" to this [Parser], and should not
+    /// be provided to anything else which modifies the
+    /// stream, including a different [Parser].
+    pub fn next_event<'de, T>(&mut self, tokens: &mut Tokens<'de, T>) -> Option<Result<Event<'de>>>
+    where
+        T: Read,
+    {
+        self.get_next_event(tokens).transpose()
+    }
+
+    /// Provides an [Iterator] interface to this [Parser],
+    /// via the given .tokens
+    #[allow(clippy::wrong_self_convention)]
+    pub fn into_iter<'a, 'b, 'de, T>(
+        &'a mut self,
+        tokens: &'b mut Tokens<'de, T>,
+    ) -> EventIter<'a, 'b, 'de, T>
+    where
+        T: Read,
+    {
+        EventIter::new(self, tokens)
+    }
+
+    /// Runs the state machine until it either provides the
+    /// next [Event], an error, or the state machine is
+    /// finished
+    fn get_next_event<'de, T>(&mut self, tokens: &mut Tokens<'de, T>) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        let mut event = None;
+
+        // Main loop, continue until an event is produced, an error
+        // is returned or we're marked as finished.
+        while !self.done && event.is_none()
+        {
+            event = self.state_transition(tokens)?;
+        }
+
+        Ok(event)
+    }
+
+    /// Process the next event in the state machine, running
+    /// the associated routine
+    fn state_transition<'de, T>(
+        &mut self,
+        tokens: &mut Tokens<'de, T>,
+    ) -> Result<Option<Event<'de>>>
+    where
+        T: Read,
+    {
+        match *self.state.top()
+        {
+            State::StreamStart => todo!(),
+            State::DocumentStart(opts) => todo!(),
+            State::DocumentContent => todo!(),
+            State::DocumentEnd => todo!(),
+            State::BlockNode => todo!(),
+            State::FlowNode => todo!(),
+            State::BlockSequenceEntry(opts) => todo!(),
+            State::BlockMappingKey(opts) => todo!(),
+            State::BlockMappingValue => todo!(),
+            State::FlowSequenceEntry(opts) => todo!(),
+            State::FlowSequenceMappingKey => todo!(),
+            State::FlowSequenceMappingValue => todo!(),
+            State::FlowSequenceMappingEnd => todo!(),
+            State::FlowMappingKey(opts) => todo!(),
+            State::FlowMappingValue(opts) => todo!(),
+
+            // State machine terminus, no more events will be produced by this parser
+            State::StreamEnd => todo!(),
+        }
+    }
+}
+
+/// Provides an [Iterator] interface to interact with
+/// [Event]s through.
+#[derive(Debug)]
+pub struct EventIter<'a, 'b, 'de, T>
+{
+    parser: &'a mut Parser,
+    reader: &'b mut Tokens<'de, T>,
+}
+
+impl<'a, 'b, 'de, T> EventIter<'a, 'b, 'de, T>
+where
+    T: Read,
+{
+    fn new(parser: &'a mut Parser, reader: &'b mut Tokens<'de, T>) -> Self
+    {
+        Self { parser, reader }
+    }
+}
+
+impl<'a, 'b, 'de, T> Iterator for EventIter<'a, 'b, 'de, T>
+where
+    T: Read,
+{
+    type Item = Result<Event<'de>>;
+
+    fn next(&mut self) -> Option<Self::Item>
+    {
+        self.parser.next_event(self.reader)
+    }
+}

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -4,6 +4,9 @@
  * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#[macro_use]
+mod macros;
+
 mod state;
 
 pub mod error;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -3,13 +3,3 @@
  * Mozilla Public License, v. 2.0. If a copy of the MPL
  * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
-#![allow(dead_code)]
-#![allow(clippy::suspicious_else_formatting)]
-
-mod error;
-mod event;
-mod queue;
-mod reader;
-mod scanner;
-mod token;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -5,3 +5,5 @@
  */
 
 mod state;
+
+pub mod error;

--- a/src/event/state.rs
+++ b/src/event/state.rs
@@ -1,0 +1,166 @@
+/*
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use std::mem;
+
+pub(in crate::event) use self::flags::*;
+
+pub(in crate::event) const INITIAL_STATE: State = State::StreamStart;
+pub(in crate::event) const END_STATE: State = State::StreamEnd;
+
+#[derive(Debug, Clone)]
+pub(in crate::event) struct StateMachine
+{
+    top:   State,
+    stack: Vec<State>,
+}
+
+impl StateMachine
+{
+    /// Instantiate a new state machine with the given
+    /// initial State.
+    pub fn new(initial: State) -> Self
+    {
+        Self {
+            top:   initial,
+            stack: Vec::default(),
+        }
+    }
+
+    /// Push a State into the current .top, adding the
+    /// previous .top to the stack, and returning a
+    /// mutable reference to the new .top.
+    pub fn push_top(&mut self, s: State) -> &mut State
+    {
+        let old = mem::replace(&mut self.top, s);
+        self.stack.push(old);
+
+        &mut self.top
+    }
+
+    /// Push a State onto the stack, returning a mutable
+    /// reference to it.
+    pub fn push(&mut self, s: State) -> &mut State
+    {
+        self.stack.push(s);
+
+        self.stack.last_mut().unwrap()
+    }
+
+    /// Pop the State stack, replacing the current .top with
+    /// the next State on the stack, returning the previous
+    /// top if a replacement was made.
+    pub fn pop(&mut self) -> Option<State>
+    {
+        self.stack.pop().map(|new| mem::replace(&mut self.top, new))
+    }
+
+    /// Immutably access the top State
+    pub fn top(&self) -> &State
+    {
+        &self.top
+    }
+
+    /// Mutably access the top State
+    pub fn top_mut(&mut self) -> &mut State
+    {
+        &mut self.top
+    }
+
+    /// Is the state machine finished?
+    pub fn is_done(&self) -> bool
+    {
+        self.stack.is_empty() && matches!(self.top, END_STATE)
+    }
+}
+
+impl Default for StateMachine
+{
+    fn default() -> Self
+    {
+        Self::new(INITIAL_STATE)
+    }
+}
+
+/// Possible states in the processing of a YAML
+/// [Token][crate::token::Token] sequence
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::event) enum State
+{
+    /// Expecting start of stream
+    StreamStart,
+    /// Expecting nothing (end of state)
+    StreamEnd,
+
+    /// Expecting start of document
+    /// :: O_IMPLICIT? | O_FIRST?
+    DocumentStart(Flags),
+    /// Expecting document content
+    DocumentContent,
+    /// Expecting end of document
+    DocumentEnd,
+
+    /// Expecting a Node in the block context
+    BlockNode,
+    /// Expecting a Node in the flow context
+    FlowNode,
+
+    /// Expecting sequence entries in the block context
+    /// :: O_FIRST?
+    BlockSequenceEntry(Flags),
+    /// Expecting mapping key in the block context
+    /// :: O_FIRST?
+    BlockMappingKey(Flags),
+    /// Expecting a mapping value in the block context
+    BlockMappingValue,
+
+    /// Expecting sequence entries in the flow context
+    /// :: O_FIRST?
+    FlowSequenceEntry(Flags),
+    /// Expecting a key in a flow sequence->mapping nested
+    /// structure
+    FlowSequenceMappingKey,
+    /// Expecting a value in a flow sequence->mapping nested
+    /// structure
+    FlowSequenceMappingValue,
+    /// Expecting the end of a flow sequence->mapping nested
+    /// structure
+    FlowSequenceMappingEnd,
+
+    /// Expecting mapping key in the flow context
+    /// :: O_FIRST?
+    FlowMappingKey(Flags),
+    /// Expecting a mapping value in the flow context
+    /// :: O_EMPTY?
+    FlowMappingValue(Flags),
+}
+
+mod flags
+{
+    use bitflags::bitflags;
+
+    /// Nil / empty flag set
+    pub const O_NIL: Flags = Flags::empty();
+    /// Is the document implicit?
+    pub const O_IMPLICIT: Flags = Flags::IMPLICIT;
+    /// Is this the first entry of the sequence/mapping,
+    /// or the first document in the stream?
+    pub const O_FIRST: Flags = Flags::FIRST;
+    /// Is the current mapping value expected to be empty?
+    pub const O_EMPTY: Flags = Flags::EMPTY;
+
+    bitflags! {
+        #[derive(Default)]
+        /// Options used by the state machine, not all options are relevant to all states.
+        pub struct Flags: u8 {
+            const IMPLICIT      = 0b00000001;
+            const ALIAS         = 0b00000010;
+            const TAG           = 0b00000100;
+            const FIRST         = 0b00001000;
+            const EMPTY         = 0b00010000;
+        }
+    }
+}

--- a/src/event/tests/macros.rs
+++ b/src/event/tests/macros.rs
@@ -1,0 +1,300 @@
+/*
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/// Generate a PeekQueue instance from the given .tokens.
+/// Note that the returned TokenEntry's read_at will be 0.
+///
+/// Usage:
+///     /1 +[ .token, ...]
+macro_rules! tokens {
+    ($($token:expr),+) => {{
+        use std::iter::FromIterator;
+        use $crate::{queue::Queue, scanner::entry::TokenEntry};
+
+        let tokens = vec![ $( $token ),+ ]
+            .into_iter()
+            .map(|token| TokenEntry::new(token, 0));
+
+        Queue::from_iter(tokens)
+    }};
+}
+
+#[rustfmt::skip]
+/// Generate an Event from the given $type, optionally setting
+/// the .start and .end marks.
+///
+/// Variants
+///     /1 { $type }, .start, .end
+///     /2 { $type } := /1 { $type }, 0, 0
+///
+///     $type :=
+///         | StreamStart ?[.encoding]
+///         | StreamEnd
+///         | DocumentStart ?[@explicit] ?[.major, .minor] ?[ [ *[.handle, .prefix] ] ]
+///         | DocumentEnd ?[@explicit]
+///         | Anchor .name
+///         | Scalar .scalar
+///         | MappingStart @.kind
+///         | MappingEnd
+///         | SequenceStart @.kind
+///         | SequenceEnd
+///
+macro_rules! event {
+    ($args:tt $(, $start:expr)? $(=> $end:expr)? ) => {{
+        #[allow(unused_imports)]
+        use $crate::event::types::{Event, EventData, self};
+
+        let (start, end) = event!(@marks $($start ,)? 0 => $($end ,)? 0);
+        Event::new(start, end, event!(@type $args))
+    }};
+
+    (@type {StreamStart $( $encoding:expr )? }) => {
+        EventData::StreamStart(types::StreamStart {
+            encoding: event!(@option $( $encoding ,)? $crate::token::StreamEncoding::UTF8)
+        })
+    };
+    (@type {StreamEnd}) => {
+        EventData::StreamEnd
+    };
+    (@type {DocumentStart $(@ $explicit:tt )? $( $major:literal , $minor:literal )? $( [ $({$handle:expr, $prefix:expr}),* ] )? }) => {
+        EventData::DocumentStart(
+            types::DocumentStart {
+                directives: types::Directives {
+                    version: event!(@option
+                        $( types::VersionDirective { major: $major, minor: $minor } ,)?
+                        $crate::event::types::DEFAULT_VERSION
+                    ),
+                    tags: std::iter::FromIterator::from_iter(
+                        std::array::IntoIter::new($crate::event::DEFAULT_TAGS).chain(vec![
+                                $($( ($crate::token::Slice::from($handle), $crate::token::Slice::from($prefix)) ),*)?
+                    ])),
+                },
+                implicit: !event!(@explicit $( $explicit ,)? implicit),
+            }
+        )
+    };
+    (@type {DocumentEnd $(@ $explicit:tt)? }) => {
+        EventData::DocumentEnd(
+            types::DocumentEnd { implicit: !event!(@explicit $( $explicit ,)? implicit) }
+        )
+    };
+    (@type {Anchor $name:expr }) => {
+        EventData::Anchor(types::Anchor { name: $name })
+    };
+    (@type {Scalar $scalar:expr }) => {
+        EventData::Scalar($scalar)
+    };
+    (@type {MappingStart @$kind:tt $(& $anchor:expr ,)? $(@ $handle:expr, $suffix:expr)? }) => {
+        EventData::MappingStart(types::Node {
+            anchor: event!(@option $( Some($anchor.into()) ,)? None),
+            tag: event!(@option $( Some(($handle.into(), $suffix.into())) ,)? None),
+            content: types::Mapping,
+            kind: event!(@kind $kind),
+        })
+    };
+    (@type {MappingEnd}) => {
+        EventData::MappingEnd
+    };
+    (@type {SequenceStart @$kind:tt $(& $anchor:expr ,)? $(@ $handle:expr, $suffix:expr)? }) => {
+        EventData::SequenceStart(types::Node {
+            anchor: event!(@option $( Some($anchor.into()) ,)? None),
+            tag: event!(@option $( Some(($handle.into(), $suffix.into())) ,)? None),
+            content: types::Sequence,
+            kind: event!(@kind $kind),
+        })
+    };
+    (@type {SequenceEnd}) => {
+        EventData::SequenceEnd
+    };
+
+    (@marks $start:expr $(, $_:expr )? => $end:expr $(, $__:expr)?) => { ($start, $end) };
+
+    (@option $return:expr $(, $_:expr)? ) => { $return };
+
+    (@explicit explicit $(, $_op:tt )? ) =>  { true };
+    (@explicit $_:tt $(, $_op:tt )? ) => { false };
+
+    (@kind Root) => { $crate::event::types::NodeKind::Root };
+    (@kind Entry) => { $crate::event::types::NodeKind::Entry };
+    (@kind Key) => { $crate::event::types::NodeKind::Key };
+    (@kind Value) => { $crate::event::types::NodeKind::Value };
+}
+
+/// Generate a Node from the given .content and .kind, with
+/// an optional .tag and/or .alias.
+///
+/// Variants
+///     /1 .content, @ .kind & .alias, @ .tag
+///     /2 .content, @ .kind & .alias
+///         := /1 .content, @ .kind & .alias, @ None
+///     /3 .content, @ .kind @ .tag
+///         := /1 .content, @ .kind & None, @ .tag
+///     /4 .content @ .kind
+///         := /1 .content, @ .kind & None, @ None
+macro_rules! node {
+    ($content:expr, @$kind:tt) => {
+        $crate::event::types::Node {
+            anchor:  None,
+            tag:     None,
+            content: $content,
+            kind: node!(@kind $kind),
+        }
+    };
+    ($content:expr, @$kind:tt @ $handle:expr, $suffix:expr) => {
+        $crate::event::types::Node {
+            anchor:  None,
+            tag:     Some((
+                $crate::token::Slice::from($handle),
+                $crate::token::Slice::from($suffix),
+            )),
+            content: $content,
+            kind: node!(@kind $kind),
+        }
+    };
+    ($content:expr, @$kind:tt & $alias:expr) => {
+        $crate::event::types::Node {
+            anchor:  Some($crate::token::Slice::from($alias)),
+            tag:     None,
+            content: $content,
+            kind: node!(@kind $kind),
+        }
+    };
+    ($content:expr, @$kind:tt & $alias:expr, @ $handle:expr, $suffix:expr) => {
+        $crate::event::types::Node {
+            anchor:  Some($crate::token::Slice::from($alias)),
+            tag:     Some((
+                $crate::token::Slice::from($handle),
+                $crate::token::Slice::from($suffix),
+            )),
+            content: $content,
+            kind: node!(@kind $kind),
+        }
+    };
+
+    (@kind Root) => { $crate::event::types::NodeKind::Root };
+    (@kind Entry) => { $crate::event::types::NodeKind::Entry };
+    (@kind Key) => { $crate::event::types::NodeKind::Key };
+    (@kind Value) => { $crate::event::types::NodeKind::Value };
+}
+
+/// Generate a Scalar from the given string .content and
+/// scalar .style
+///
+/// Modifiers
+///     ~ := Content::Scalar( ... )
+///
+/// Variants
+///     /1 .content, .style
+///     /2 .content := /1 .content, ScalarStyle::Plain
+macro_rules! scalar {
+    (~ $content:expr $(, $style:expr)? ) => {
+        $crate::event::types::Content::Scalar( scalar!($content $(, $style)?) )
+    };
+    ($content:expr) => {
+        $crate::event::types::Scalar::Eager {
+            data:  $crate::token::Slice::from($content),
+            style: $crate::token::ScalarStyle::Plain,
+        }
+    };
+    ($content:expr, $style:expr) => {
+        $crate::event::types::Scalar::Eager {
+            data:  $crate::token::Slice::from($content),
+            style: $style,
+        }
+    };
+}
+
+/// Generate a Slice from the given .content
+///
+/// Variants
+///     /1 .content
+macro_rules! cow {
+    ($content:expr) => {
+        $crate::token::Slice::from($content)
+    };
+}
+
+/// Test harness for Events. Takes the given PeekQueue
+/// .tokens and tests a Parser's output Events against the
+/// given .match set, optionally taking a context .msg.
+///
+/// Variants
+///     /1 .tokens => +[ $match ?[=> .msg], ]
+///
+///     $match :=
+///         | | .event
+///         | @ .option(Event)
+///         | > .result(Event)
+macro_rules! events {
+    ($tokens:expr => $($op:tt $match:expr $(=> $msg:expr)?),+) => {{
+        use $crate::{reader::{borrow::BorrowReader, Reader, PeekReader}, scanner::flag::O_ZEROED};
+
+        fn __events<'de>(mut parser: ParseIter<'de>) -> anyhow::Result<()>
+        {
+            $( events!(@unwrap $op parser => $match $(=> $msg)?); )+
+
+            Ok(())
+        }
+
+        let reader = BorrowReader::new("");
+        let iter = PeekReader::new(Reader::from_parts(
+            &reader,
+            O_ZEROED,
+            $tokens,
+            true,
+        ));
+
+       if let Err(e) = __events(ParseIter::new(iter)) {
+           panic!("events! error: {}", e)
+       }
+
+       ()
+    }};
+
+
+    (@unwrap | $parser:expr => $event:expr $(=> $msg:tt)? ) => {
+        events!(@token $parser, $event $(=> $msg)? )
+    };
+    (@unwrap @ $parser:expr => $expected:expr $(=> $msg:tt)? ) => {
+        assert_eq!($parser.next().transpose()?, $expected $(, $msg )?)
+    };
+    (@unwrap > $parser:expr => $expected:expr $(=> $msg:tt)? ) => {
+        let result = match $parser.next()
+        {
+            Some(result) => result,
+            None => anyhow::bail!("Unexpected end of events, was expecting: {:?} ~{:?}", $expected, $parser.tokens.queue())
+        };
+
+        assert_eq!(result, $expected)
+    };
+
+    (@token $parser:expr, $expected:expr) => {
+        let event = match $parser.next()
+        {
+            Some(r) => match r
+            {
+                Ok(r) => r,
+                Err(e) => anyhow::bail!("Expected event {:?} got error: {} ~{:?}", $expected, e, $parser.tokens.queue()),
+            }
+            None => anyhow::bail!("Unexpected end of events, was expecting: {:?} ~{:?}", $expected, $parser.tokens.queue())
+        };
+
+        assert_eq!(event, $expected)
+    };
+    (@token $parser:expr, $event:expr => $msg:tt) => {
+        let event = match $parser.next()
+        {
+            Some(r) => match r
+            {
+                Ok(r) => r,
+                Err(e) => anyhow::bail!("{}: {:?} got error: {} ~{:?}", $msg, $expected, e, $parser.tokens.queue()),
+            }
+            None => anyhow::bail!("Unexpected end of events, was expecting: {:?} ~{:?}", $expected, $parser.tokens.queue())
+        };
+
+        assert_eq!(event, $expected)
+    };
+}

--- a/src/event/types.rs
+++ b/src/event/types.rs
@@ -1,0 +1,354 @@
+/*
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! Contains the various types used by [Event]s to represent
+//! YAML.
+
+use std::{array::IntoIter as ArrayIter, borrow::Cow, collections::HashMap};
+
+use crate::{
+    scanner::{entry::Lazy, error::ScanResult},
+    token::{ScalarStyle, Slice, StreamEncoding, Token},
+};
+
+pub const DEFAULT_TAGS: [(Slice<'static>, Slice<'static>); 2] = [
+    (Cow::Borrowed("!"), Cow::Borrowed("!")),
+    (Cow::Borrowed("!!"), Cow::Borrowed("tag:yaml.org,2002:")),
+];
+pub const DEFAULT_VERSION: VersionDirective = VersionDirective { major: 1, minor: 2 };
+pub const EMPTY_SCALAR: Scalar<'static> = Scalar::empty();
+
+/// Specific YAML productions found in the YAML stream. Each
+/// Event has a start and end mark indicating an approximate
+/// range that is represented by the given Event. See
+/// [EventData] for all of the possible Event variants.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Event<'de>
+{
+    start_mark: usize,
+    end_mark:   usize,
+    inner:      EventData<'de>,
+}
+
+impl<'de> Event<'de>
+{
+    pub fn new(start_mark: usize, end_mark: usize, event: EventData<'de>) -> Self
+    {
+        Self {
+            start_mark,
+            end_mark,
+            inner: event,
+        }
+    }
+
+    pub fn start(&self) -> usize
+    {
+        self.start_mark
+    }
+
+    pub fn end(&self) -> usize
+    {
+        self.end_mark
+    }
+
+    pub fn data(&self) -> &EventData<'de>
+    {
+        &self.inner
+    }
+
+    pub fn data_mut(&mut self) -> &mut EventData<'de>
+    {
+        &mut self.inner
+    }
+}
+
+/// The possible variants of an [Event]. See the
+/// documentation on each variant for an explanation of what
+/// each variant represents.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EventData<'de>
+{
+    /// Beginning of event stream, always the first token
+    /// produced, and only will be produced once per
+    /// event stream
+    StreamStart(StreamStart),
+    /// End of events, always the last event produced, and
+    /// no more events will be produced after seeing this
+    /// token
+    StreamEnd,
+
+    /// Start of document content, once seen, all future
+    /// events belong to this document's scope,
+    /// and any tag resolution or version specific behavior
+    /// should use the attached directives
+    DocumentStart(DocumentStart<'de>),
+    /// End of document content, this event may be followed
+    /// either by another DocumentStart, or
+    /// StreamEnd event.
+    DocumentEnd(DocumentEnd),
+
+    /// An alias point connected to a previously seen
+    /// `Scalar`, `MappingStart`, or `SequenceStart`
+    /// [Node].anchor, the caller must keep track of
+    /// this information
+    Alias(Alias<'de>),
+    /// A scalar leaf node, containing (perhaps lazy)
+    /// unicode slice content
+    Scalar(Node<'de, Scalar<'de>>),
+
+    /// Start of a YAML key value production, followed by
+    /// zero or more of:
+    ///
+    /// `[ MappingStart, SequenceStart, Scalar, Anchor ]`
+    ///
+    /// until a `MappingEnd` is reached
+    MappingStart(Node<'de, Mapping>),
+    /// End of a YAML key value production
+    MappingEnd,
+    /// Start of a YAML array production, followed by zero
+    /// or more of:
+    ///
+    /// `[ MappingStart, SequenceStart, Scalar, Anchor ]`
+    ///
+    /// until a `SequenceEnd` is reached
+    SequenceStart(Node<'de, Sequence>),
+    /// End of a YAML array production
+    SequenceEnd,
+}
+
+/// Wrapper around [Event] variants that correspond to a
+/// YAML node production -- that is, those that may have
+/// associated tags or aliases.
+///
+/// One of:
+///
+///   `[Scalar, MappingStart, SequenceStart]`
+#[derive(Debug, Clone, PartialEq)]
+pub struct Node<'de, T: 'de>
+{
+    /// The alias applied to this node (if any)
+    pub anchor:  Option<Slice<'de>>,
+    /// The tag applied to this node (if any)
+    pub tag:     Option<(Slice<'de>, Slice<'de>)>,
+    /// The node's content if simple, or a hint about the
+    /// complex structure type
+    pub content: T,
+    /// Contextual information about this Node
+    pub kind:    NodeKind,
+}
+
+/// Representation of a YAML scalar node, either eagerly
+/// evaluated and thus immediately available or lazily
+/// evaluated, in which case a caller may trigger a fallible
+/// evaluation on demand.
+#[derive(Debug, Clone)]
+pub enum Scalar<'de>
+{
+    Eager
+    {
+        data:  Slice<'de>,
+        style: ScalarStyle,
+    },
+    Lazy
+    {
+        data: Box<Lazy<'de>>
+    },
+}
+
+impl<'de> Scalar<'de>
+{
+    pub fn evaluate(self) -> ScanResult<Self>
+    {
+        match self
+        {
+            eager @ Scalar::Eager { .. } => Ok(eager),
+            Scalar::Lazy { data } => data.into_token().map(|token| match token
+            {
+                Token::Scalar(data, style) => Self::Eager { data, style },
+                // Only scalars can be deferred
+                _ => unreachable!(),
+            }),
+        }
+    }
+
+    pub fn ref_evaluate(&mut self) -> ScanResult<()>
+    {
+        let this = std::mem::take(self);
+
+        *self = this.evaluate()?;
+
+        Ok(())
+    }
+}
+
+impl Scalar<'static>
+{
+    pub const fn empty() -> Self
+    {
+        Self::Eager {
+            data:  Slice::Borrowed(""),
+            style: ScalarStyle::Plain,
+        }
+    }
+}
+
+impl<'de> PartialEq for Scalar<'de>
+{
+    fn eq(&self, other: &Self) -> bool
+    {
+        match (self, other)
+        {
+            (
+                Self::Eager {
+                    data: l_data,
+                    style: l_style,
+                },
+                Self::Eager {
+                    data: r_data,
+                    style: r_style,
+                },
+            ) => l_data == r_data && l_style == r_style,
+            _ => false,
+        }
+    }
+}
+
+impl Default for Scalar<'_>
+{
+    fn default() -> Self
+    {
+        Self::Eager {
+            data:  "".into(),
+            style: ScalarStyle::Plain,
+        }
+    }
+}
+
+/// Contextual information about this [Node]'s position in
+/// the YAML byte stream
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind
+{
+    /// Top level [Node] of the YAML document, will only
+    /// (and always) be found on the first Node of
+    /// each YAML document
+    Root,
+
+    /// Entry in a YAML sequence
+    ///
+    /// Example:
+    ///
+    ///   ---
+    ///   - 'A YAML scalar in a sequence'
+    ///   ...
+    Entry,
+
+    /// A key in a YAML mapping
+    ///
+    /// Example:
+    ///
+    ///   ---
+    ///   A YAML key: "..."
+    /// # ^^^^^^^^^^
+    ///   ...
+    Key,
+    /// A value in a YAML mapping
+    ///
+    /// Example:
+    ///
+    ///   ---
+    ///   "...": "A YAML value"
+    /// #         ^^^^^^^^^^^^
+    ///   ...
+    Value,
+}
+
+/// StreamStart [Event] contents
+#[derive(Debug, Clone, PartialEq)]
+pub struct StreamStart
+{
+    /// Encoding used in the YAML byte stream
+    pub encoding: StreamEncoding,
+}
+
+/// DocumentStart [Event] contents
+#[derive(Debug, Clone, PartialEq)]
+pub struct DocumentStart<'de>
+{
+    pub directives: Directives<'de>,
+    /// Was this event present in the stream, or inferred?
+    pub implicit:   bool,
+}
+
+/// DocumentEnd [Event] contents
+#[derive(Debug, Clone, PartialEq)]
+pub struct DocumentEnd
+{
+    /// Was this event present in the stream, or inferred?
+    pub implicit: bool,
+}
+
+/// Anchor [Event] contents
+#[derive(Debug, Clone, PartialEq)]
+pub struct Alias<'de>
+{
+    /// Name of the alias this anchor refers to.
+    pub name: Slice<'de>,
+}
+
+/// MappingStart [Event] stub
+#[derive(Debug, Clone, PartialEq)]
+pub struct Mapping;
+/// SequenceStart [Event] stub
+#[derive(Debug, Clone, PartialEq)]
+pub struct Sequence;
+
+/// YAML Directives belonging to a document
+#[derive(Debug, Clone, PartialEq)]
+pub struct Directives<'de>
+{
+    /// %YAML directive, indicating the YAML schema version
+    /// used in for the current document
+    pub version: VersionDirective,
+    /// Map of %TAG directives found in the stream
+    pub tags:    TagDirectives<'de>,
+}
+
+impl<'de> Directives<'de>
+{
+    pub fn empty() -> Self
+    {
+        Self {
+            version: DEFAULT_VERSION,
+            tags:    TagDirectives::new(),
+        }
+    }
+}
+
+impl Default for Directives<'_>
+{
+    fn default() -> Self
+    {
+        Self {
+            version: DEFAULT_VERSION,
+            tags:    ArrayIter::new(DEFAULT_TAGS).collect(),
+        }
+    }
+}
+
+/// %YAML directive representation, containing the .major
+/// and .minor version of the current document in the YAML
+/// stream
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VersionDirective
+{
+    pub major: u8,
+    pub minor: u8,
+}
+
+/// Typedef map of tag directives present in the current
+/// document
+pub type TagDirectives<'de> = HashMap<Slice<'de>, Slice<'de>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@
 
 mod error;
 mod queue;
+mod reader;
 mod scanner;
 mod token;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -23,7 +23,7 @@ use std::{
 /// A min heap data structure that keeps a stable ordering
 /// of elements, ensuring that otherwise equal items are
 /// returned in the order added
-pub(crate) struct Queue<T>
+pub struct Queue<T>
 {
     heap:      BinaryHeap<Reverse<QueueEntry<T>>>,
     increment: usize,
@@ -181,7 +181,7 @@ where
     }
 }
 
-pub(crate) struct QueueIntoIter<T>
+pub struct QueueIntoIter<T>
 {
     inner: Queue<T>,
 }

--- a/src/reader/borrow.rs
+++ b/src/reader/borrow.rs
@@ -63,3 +63,12 @@ impl<'a> Read for BorrowReader<'a>
 }
 
 impl private::Sealed for BorrowReader<'_> {}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+    use crate::reader::test_util::test_reader;
+
+    test_reader! {BorrowReader::new}
+}

--- a/src/reader/borrow.rs
+++ b/src/reader/borrow.rs
@@ -1,0 +1,65 @@
+/*
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use super::{error::ReaderResult as Result, private, Read, Reader};
+use crate::{
+    queue::Queue,
+    scanner::{
+        entry::TokenEntry,
+        flag::{Flags, O_EXTENDABLE},
+        Scanner,
+    },
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct BorrowReader<'de>
+{
+    data: &'de str,
+}
+
+impl<'de> BorrowReader<'de>
+{
+    pub fn new(data: &'de str) -> Self
+    {
+        Self { data }
+    }
+
+    pub fn try_from_bytes(data: &'de [u8]) -> Result<Self>
+    {
+        let this = std::str::from_utf8(data).map(Self::new)?;
+
+        Ok(this)
+    }
+
+    pub fn new_reader(&'de self, opts: Flags) -> Reader<'de, Self>
+    {
+        Reader::new(self, opts)
+    }
+}
+
+impl<'a> Read for BorrowReader<'a>
+{
+    fn drive<'de>(
+        &'de self,
+        scanner: &mut Scanner,
+        queue: &mut Queue<TokenEntry<'de>>,
+        options: Flags,
+    ) -> Result<()>
+    {
+        // This implementation is never extendable, so we remove the
+        // option from the set if it exists
+        scanner.scan_tokens(options & !O_EXTENDABLE, self.data, queue)?;
+
+        Ok(())
+    }
+
+    unsafe fn consume(&self, _bound: usize) -> Result<()>
+    {
+        Ok(())
+    }
+}
+
+impl private::Sealed for BorrowReader<'_> {}

--- a/src/reader/error.rs
+++ b/src/reader/error.rs
@@ -1,0 +1,64 @@
+/*
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use std::{error::Error as StdError, fmt, io, str::Utf8Error};
+
+use crate::scanner::error::ScanError;
+
+pub type ReaderResult<T> = std::result::Result<T, ReaderError>;
+
+#[derive(Debug)]
+pub enum ReaderError
+{
+    UTF8(Utf8Error),
+    IO(io::Error),
+    Scanner(ScanError),
+}
+
+impl fmt::Display for ReaderError
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
+    {
+        fmt::Debug::fmt(&self, f)
+    }
+}
+
+impl StdError for ReaderError
+{
+    fn source(&self) -> Option<&(dyn StdError + 'static)>
+    {
+        match self
+        {
+            ReaderError::UTF8(ref e) => Some(e),
+            ReaderError::IO(ref e) => Some(e),
+            ReaderError::Scanner(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<Utf8Error> for ReaderError
+{
+    fn from(e: Utf8Error) -> Self
+    {
+        Self::UTF8(e)
+    }
+}
+
+impl From<io::Error> for ReaderError
+{
+    fn from(e: io::Error) -> Self
+    {
+        Self::IO(e)
+    }
+}
+
+impl From<ScanError> for ReaderError
+{
+    fn from(e: ScanError) -> Self
+    {
+        Self::Scanner(e)
+    }
+}

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -7,6 +7,7 @@
 mod error;
 
 pub mod borrow;
+pub mod owned;
 
 pub use error::{ReaderError, ReaderResult};
 use private::Sealed;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1,0 +1,57 @@
+/*
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+mod error;
+
+pub use error::{ReaderError, ReaderResult};
+use private::Sealed;
+
+use crate::{
+    queue::Queue,
+    reader::error::ReaderResult as Result,
+    scanner::{entry::TokenEntry, flag::Flags, Scanner},
+};
+
+/// Sealed interface over the functionality that
+/// transforms a byte stream into [Token][crate::token::
+/// Token]s.
+///
+/// Note the key feature here is `&'de self`. Namely, an
+/// immutable reference through which any internal mutation
+/// must not be visible
+pub trait Read: std::fmt::Debug + Sealed
+{
+    /// Drive the .scanner from the byte stream with the
+    /// provided .options, placing output into the
+    /// .queue
+    fn drive<'de>(
+        &'de self,
+        scanner: &mut Scanner,
+        queue: &mut Queue<TokenEntry<'de>>,
+        options: Flags,
+    ) -> Result<()>;
+
+    /// Hint to the underlying implementation that no live
+    /// references exist to any data read below
+    /// the given .bound, and that it may unload the given
+    /// memory.
+    ///
+    /// SAFETY:
+    ///     It is only safe to call this function after the
+    ///     caller has ensured there cannot be any live
+    ///     references to content below the provided .bound.
+    unsafe fn consume(&self, _bound: usize) -> Result<()>
+    {
+        Ok(())
+    }
+}
+
+mod private
+{
+    pub trait Sealed
+    {
+    }
+}

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -6,6 +6,8 @@
 
 mod error;
 
+pub mod borrow;
+
 pub use error::{ReaderError, ReaderResult};
 use private::Sealed;
 

--- a/src/reader/owned.rs
+++ b/src/reader/owned.rs
@@ -274,3 +274,21 @@ impl fmt::Debug for Take<'_>
             .finish()
     }
 }
+
+#[cfg(test)]
+mod tests
+{
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::reader::test_util::test_reader;
+
+    fn str_to_owned_reader(data: &str) -> OwnedReader
+    {
+        let read = Cursor::new(data.as_bytes().to_vec());
+
+        OwnedReader::new(read)
+    }
+
+    test_reader! {str_to_owned_reader}
+}

--- a/src/reader/owned.rs
+++ b/src/reader/owned.rs
@@ -1,0 +1,276 @@
+/*
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use std::{cell::UnsafeCell, fmt, io};
+
+use super::{error::ReaderResult as Result, private::Sealed, Read, Reader};
+use crate::{
+    queue::Queue,
+    scanner::{
+        entry::TokenEntry,
+        error::ScanError,
+        flag::{Flags, O_EXTENDABLE},
+        Scanner,
+    },
+};
+
+const DEFAULT_BUFFER_SIZE: usize = 8 * 1024;
+
+#[derive(Debug)]
+pub(crate) struct OwnedReader
+{
+    inner: ReadHolder,
+}
+
+impl OwnedReader
+{
+    pub fn new<T>(src: T) -> Self
+    where
+        T: io::Read + 'static,
+    {
+        let inner = ReadHolder::new(src);
+
+        Self { inner }
+    }
+
+    pub fn new_reader(&self, opts: Flags) -> Reader<'_, Self>
+    {
+        Reader::new(self, opts)
+    }
+
+    fn drive_scanner<'de>(
+        &'de self,
+        scanner: &mut Scanner,
+        queue: &mut Queue<TokenEntry<'de>>,
+        mut opts: Flags,
+    ) -> Result<()>
+    {
+        loop
+        {
+            match self.inner.is_exhausted()
+            {
+                true => opts.remove(O_EXTENDABLE),
+                false => opts.insert(O_EXTENDABLE),
+            }
+
+            match scanner.scan_tokens(opts, self.inner.data(), queue)
+            {
+                Err(ScanError::Extend) =>
+                {
+                    let read_to = scanner.offset();
+
+                    self.inner.read_next_chunk(Some(read_to))?;
+
+                    scanner.reset_offset();
+                },
+
+                Ok(_) => return Ok(()),
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+}
+
+impl Read for OwnedReader
+{
+    fn drive<'de>(
+        &'de self,
+        scanner: &mut Scanner,
+        queue: &mut Queue<TokenEntry<'de>>,
+        options: Flags,
+    ) -> Result<()>
+    {
+        self.drive_scanner(scanner, queue, options)
+    }
+
+    unsafe fn consume(&self, _bound: usize) -> Result<()>
+    {
+        Ok(())
+    }
+}
+
+impl Sealed for OwnedReader {}
+
+#[derive(Debug)]
+struct ReadHolder
+{
+    inner: UnsafeCell<Impl>,
+}
+
+impl ReadHolder
+{
+    pub fn new<T>(src: T) -> Self
+    where
+        T: io::Read + 'static,
+    {
+        let inner = Impl::new(src).into();
+
+        Self { inner }
+    }
+
+    pub fn read_next_chunk(&self, read_to: Option<usize>) -> Result<()>
+    {
+        let inner: &mut Impl = unsafe { &mut *self.inner.get() };
+
+        inner.refresh_buffer(read_to)
+    }
+
+    pub fn data(&self) -> &str
+    {
+        // SAFETY:
+        //
+        // We never drop the contents being referenced here.
+        //
+        // The whole point of this structure is to ensure we never
+        // reallocate *any* of Impl's contents, only moving
+        // the (cap,len,ptr) triple that makes up Vecs (and
+        // consequently Strings)
+        //
+        // This section REQUIRES the following invariants:
+        //
+        //  1. Impl's .head and .tail(s) never perform any operation
+        //     that could invalidate references
+        //     (realloc of any kind)
+        //  2. Impl must not drop any of the allocated data before
+        //     ReadHolder (ourselves) is dropped
+        let inner: &Impl = unsafe { &*self.inner.get() };
+
+        inner.data()
+    }
+
+    fn is_exhausted(&self) -> bool
+    {
+        let inner: &Impl = unsafe { &*self.inner.get() };
+
+        inner.exhausted
+    }
+}
+
+struct Impl
+{
+    head: String,
+    tail: Vec<String>,
+
+    source:    Box<dyn io::Read + 'static>,
+    exhausted: bool,
+}
+
+impl Impl
+{
+    pub fn new<T>(src: T) -> Self
+    where
+        T: io::Read + 'static,
+    {
+        let source = Box::new(src);
+
+        Self {
+            head: String::new(),
+            tail: Vec::new(),
+
+            source,
+            exhausted: false,
+        }
+    }
+
+    pub fn data(&self) -> &str
+    {
+        &self.head
+    }
+
+    fn refresh_buffer(&mut self, copy_from: Option<usize>) -> Result<()>
+    {
+        // Calculate next allocation chunk
+        let cap = (DEFAULT_BUFFER_SIZE * usize::max(self.tail.len(), 1) + copy_from.unwrap_or(0))
+            .next_power_of_two();
+        let mut new = Vec::new();
+
+        // Copy any data that is marked as unread into the next
+        // buffer
+        if let Some(mark) = copy_from
+        {
+            new.extend_from_slice(&self.head.as_bytes()[mark..]);
+        }
+
+        // Fill the new buffer, checking if .src has been exhausted
+        self.exhausted = read_fill(Take::new(&mut self.source, cap), &mut new)?;
+
+        // Validate buffer is UTF8
+        let new = String::from_utf8(new).map_err(|e| e.utf8_error())?;
+
+        // Swap the new and old heads, pushing the old head into the
+        // held tails
+        let old = std::mem::replace(&mut self.head, new);
+        self.tail.push(old);
+
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Impl
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
+    {
+        f.debug_struct("Impl")
+            .field("head", &self.head)
+            .field("tail", &self.tail)
+            .field("source", &"dyn <std::io::Read>")
+            .field("exhausted", &self.exhausted)
+            .finish()
+    }
+}
+
+fn read_fill<T>(mut src: T, buf: &mut Vec<u8>) -> io::Result<bool>
+where
+    T: io::Read,
+{
+    let amt = src.read_to_end(buf)?;
+
+    Ok(amt == 0)
+}
+
+struct Take<'a>
+{
+    limit: usize,
+    inner: &'a mut dyn io::Read,
+}
+
+impl<'a> Take<'a>
+{
+    fn new(read: &'a mut dyn io::Read, limit: usize) -> Self
+    {
+        Self { inner: read, limit }
+    }
+}
+
+impl<'a> io::Read for Take<'a>
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize>
+    {
+        // Don't call into inner reader at all at EOF because it may
+        // still block
+        if self.limit == 0
+        {
+            return Ok(0);
+        }
+
+        let max = usize::min(buf.len(), self.limit);
+        let n = self.inner.read(&mut buf[..max])?;
+        self.limit -= n;
+
+        Ok(n)
+    }
+}
+
+impl fmt::Debug for Take<'_>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
+    {
+        f.debug_struct("Take")
+            .field("limit", &self.limit)
+            .field("inner", &"dyn <std::io::Read>")
+            .finish()
+    }
+}

--- a/src/scanner/directive.rs
+++ b/src/scanner/directive.rs
@@ -20,7 +20,7 @@ use crate::{
 pub(in crate::scanner) fn scan_directive<'de>(
     opts: Flags,
     buffer: &mut &'de str,
-    mut stats: &mut MStats,
+    stats: &mut MStats,
     kind: &DirectiveKind,
 ) -> Result<Token<'de>>
 {
@@ -29,10 +29,7 @@ pub(in crate::scanner) fn scan_directive<'de>(
         DirectiveKind::Version =>
         {
             // Chomp any preceding whitespace
-            advance!(
-                *buffer,
-                eat_whitespace(opts, buffer, &mut stats, !COMMENTS)?
-            );
+            advance!(*buffer, eat_whitespace(opts, buffer, stats, !COMMENTS)?);
 
             // %YAML 1.1
             //       ^
@@ -55,13 +52,10 @@ pub(in crate::scanner) fn scan_directive<'de>(
         DirectiveKind::Tag =>
         {
             // Chomp any spaces up to the handle
-            advance!(
-                *buffer,
-                eat_whitespace(opts, buffer, &mut stats, !COMMENTS)?
-            );
+            advance!(*buffer, eat_whitespace(opts, buffer, stats, !COMMENTS)?);
 
             // Scan the directive, copying if necessary
-            let (token, amt) = scan_tag_directive(opts, buffer, &mut stats)?;
+            let (token, amt) = scan_tag_directive(opts, buffer, stats)?;
             advance!(*buffer, amt);
 
             Ok(token)

--- a/src/scanner/entry.rs
+++ b/src/scanner/entry.rs
@@ -135,7 +135,7 @@ impl<'de> From<flow::Deferred<'de>> for Lazy<'de>
     fn from(inner: flow::Deferred<'de>) -> Self
     {
         Self {
-            inner: LazyImpl::ScalarF(inner),
+            inner: LazyImpl::Flow(inner),
         }
     }
 }
@@ -145,7 +145,7 @@ impl<'de> From<plain::Deferred<'de>> for Lazy<'de>
     fn from(inner: plain::Deferred<'de>) -> Self
     {
         Self {
-            inner: LazyImpl::ScalarP(inner),
+            inner: LazyImpl::Plain(inner),
         }
     }
 }
@@ -155,7 +155,7 @@ impl<'de> From<block::Deferred<'de>> for Lazy<'de>
     fn from(inner: block::Deferred<'de>) -> Self
     {
         Self {
-            inner: LazyImpl::ScalarB(inner),
+            inner: LazyImpl::Block(inner),
         }
     }
 }
@@ -163,9 +163,9 @@ impl<'de> From<block::Deferred<'de>> for Lazy<'de>
 #[derive(Debug, Clone)]
 enum LazyImpl<'de>
 {
-    ScalarF(flow::Deferred<'de>),
-    ScalarP(plain::Deferred<'de>),
-    ScalarB(block::Deferred<'de>),
+    Flow(flow::Deferred<'de>),
+    Plain(plain::Deferred<'de>),
+    Block(block::Deferred<'de>),
 }
 
 impl<'de> LazyImpl<'de>
@@ -174,9 +174,9 @@ impl<'de> LazyImpl<'de>
     {
         match self
         {
-            Self::ScalarF(inner) => inner.into_token(),
-            Self::ScalarP(inner) => inner.into_token(),
-            Self::ScalarB(inner) => inner.into_token(),
+            Self::Flow(inner) => inner.into_token(),
+            Self::Plain(inner) => inner.into_token(),
+            Self::Block(inner) => inner.into_token(),
         }
     }
 }

--- a/src/scanner/entry.rs
+++ b/src/scanner/entry.rs
@@ -117,7 +117,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Lazy<'de>
 {
     inner: LazyImpl<'de>,
@@ -160,7 +160,7 @@ impl<'de> From<block::Deferred<'de>> for Lazy<'de>
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum LazyImpl<'de>
 {
     ScalarF(flow::Deferred<'de>),

--- a/src/scanner/entry.rs
+++ b/src/scanner/entry.rs
@@ -11,7 +11,7 @@ use crate::{
         error::ScanResult as Result,
         scalar::{block, flow, plain},
     },
-    token::Token,
+    token::{Marker, Token},
 };
 
 /// A wrapper around a token containing a custom Ord impl
@@ -41,6 +41,11 @@ impl<'de> TokenEntry<'de>
     pub fn read_at(&self) -> usize
     {
         self.read_at
+    }
+
+    pub fn marker(&self) -> Marker
+    {
+        self.wrap.marker()
     }
 
     pub fn is_processed(&self) -> bool
@@ -89,6 +94,15 @@ pub enum MaybeToken<'de>
 
 impl<'de> MaybeToken<'de>
 {
+    pub fn marker(&self) -> Marker
+    {
+        match self
+        {
+            MaybeToken::Token(t) => t.into(),
+            MaybeToken::Deferred(l) => l.marker(),
+        }
+    }
+
     pub fn into_token(self) -> Result<Token<'de>>
     {
         match self
@@ -125,6 +139,11 @@ pub struct Lazy<'de>
 
 impl<'de> Lazy<'de>
 {
+    pub fn marker(&self) -> Marker
+    {
+        self.inner.marker()
+    }
+
     pub fn into_token(self) -> Result<Token<'de>>
     {
         self.inner.into_token()
@@ -170,6 +189,11 @@ enum LazyImpl<'de>
 
 impl<'de> LazyImpl<'de>
 {
+    pub fn marker(&self) -> Marker
+    {
+        Marker::Scalar
+    }
+
     pub fn into_token(self) -> Result<Token<'de>>
     {
         match self

--- a/src/scanner/entry.rs
+++ b/src/scanner/entry.rs
@@ -20,7 +20,7 @@ use crate::{
 /// Note that this wrapper *does not* compare tokens, so if
 /// you desire that ensure that you compare them directly
 #[derive(Debug)]
-pub(crate) struct TokenEntry<'de>
+pub struct TokenEntry<'de>
 {
     pub wrap: MaybeToken<'de>,
     read_at:  usize,

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -12,9 +12,9 @@ mod macros;
 mod anchor;
 mod context;
 mod directive;
-mod entry;
-mod error;
-mod flag;
+pub mod entry;
+pub mod error;
+pub mod flag;
 mod key;
 mod scalar;
 mod stats;
@@ -40,7 +40,7 @@ use crate::{
 type Tokens<'de> = Queue<TokenEntry<'de>>;
 
 #[derive(Debug)]
-struct Scanner
+pub struct Scanner
 {
     /// Offset into the data buffer to start at
     offset: usize,

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -105,6 +105,16 @@ impl Scanner
         Ok(num_tokens)
     }
 
+    pub fn offset(&self) -> usize
+    {
+        self.offset
+    }
+
+    pub fn reset_offset(&mut self)
+    {
+        self.offset = 0;
+    }
+
     fn scan_next_token<'de>(
         &mut self,
         opts: Flags,

--- a/src/scanner/scalar/block.rs
+++ b/src/scanner/scalar/block.rs
@@ -194,7 +194,7 @@ pub(in crate::scanner) fn scan_block_scalar_eager<'de>(
         //    I can be borrowed
         if can_borrow && lines > 0
         {
-            scratch.extend_from_slice(&base[content_start..content_end].as_bytes());
+            scratch.extend_from_slice(base[content_start..content_end].as_bytes());
 
             can_borrow = false
         }
@@ -540,7 +540,7 @@ fn scan_chomp<'de>(
                 // when .style == Keep
                 _ =>
                 {
-                    scratch.extend_from_slice(&base[start..end].as_bytes());
+                    scratch.extend_from_slice(base[start..end].as_bytes());
 
                     while lines > 0
                     {

--- a/src/scanner/stats.rs
+++ b/src/scanner/stats.rs
@@ -16,7 +16,7 @@ use std::ops::{Add, AddAssign};
 /// Vessel for tracking various stats about the underlying
 /// buffer that are required for correct parsing of certain
 /// elements, and when contextualizing an error.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(in crate::scanner) struct MStats
 {
     /// Amount of bytes read from the underlying byte stream
@@ -46,18 +46,6 @@ impl MStats
         {
             0 => self.column += column,
             _ => self.column = column,
-        }
-    }
-}
-
-impl Default for MStats
-{
-    fn default() -> Self
-    {
-        Self {
-            read:   0,
-            lines:  0,
-            column: 0,
         }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -200,7 +200,7 @@ impl PartialEq<Token<'_>> for Marker
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum StreamEncoding
 {
     UTF8,


### PR DESCRIPTION
This PR adds the first component of this library's public API: the [`Parser`].

A [`Parser`] is provided a [`Read`](./src/reader/mod.rs) implementation that is responsible for converting the underlying byte stream into [`TokenEntry`](./src/scanner/entry.rs)s, which the [`Parser`] is responsible for converting into [`Event`](./src/event/types.rs)s. These _Events_ are the primitive type that all other (de-serialization) functionality will be built on.

## The `Read` trait

This is my solution to the problem of #4. It keeps the borrowed case extremely simple, while requiring some thought on how to tackle the owned case. I'll quote an excerpt from the commit which introduced `Read`:

<details>
<summary>Expand excerpt</summary>

> Any Read implementation must uphold the contract:
> 
>     (&'de self) -> Tokens<'de>
> 
> That is, any borrows into the backing bytes given out must not be mutated
> in any way.
>
> ...
> 
> I've decided to introduce a "Stacked Borrow"
> pattern with the use of a little unsafe.
> 
> ```
> ; A rust vector is just a capacity, length and ptr to somewhere in the
> ; heap
> VEC := (cap,len,ptr)
> 
> ; Each OwnedReader keeps two VECs, one for bytes (u8) and another for
> ; VECs of bytes
> OwnedReader := {
>   head: (cap, len, ptr)
>   tail: (cap, len, ptr)
> }
> 
> ; Demonstration of the various memory segments stored on the program's heap
> ; and how the OwnedReader's ptrs connect
> HEAP := {
>   head.ptr->[u8..]
>   tail.ptr->[VEC..]
>   tail[0].ptr->[u8..]
>   tail[n].ptr->[u8..]
> }
> ```
>
> The OwnedReader makes a promise to NEVER call realloc on an existing
> heap segment; therefore any references given out to heap segments are
> immutable, fulfilling the contract required by the Parser (and Scanner).
> 
> Instead, if/when more of the byte stream is requested, it will allocate
> a new .head and swapping out the old .head onto the .tail stack thus
> keep the memory live.

</details>

## `Event` stream details

An explanation of the expected `Event` stream productions that a [`Parser`] would produce, taken from [`lib/event`](./src/event/mod.rs) module docs:

<details>
<summary>Expand excerpt</summary>

> Each event produced represents an important semantic
> change in the underlying YAML byte stream. Broadly,
> these can be categorized into three spaces:
> 
> 1. Virtual / Marker
> - [StreamStart](Event::StreamStart),
> - [StreamEnd](Event::StreamEnd),
> - [DocumentStart](Event::DocumentStart),
> - [DocumentEnd](Event::DocumentEnd),
> 
> 2. Nesting change (+-)
> - [MappingStart](Event::MappingStart),
> - [MappingEnd](Event::MappingEnd),
> - [SequenceStart](Event::SequenceStart),
> - [SequenceEnd](Event::SequenceEnd),
> 
> 3. Data / Alias
> - [Scalar](Event::Scalar),
> - [Alias](Event::Alias),
> 
> Together, these are used to produce the following
> productions:
> 
> ```text
> stream          := StreamStart document+ StreamEnd
> document        := DocumentStart content? DocumentEnd
> content         := Scalar | collection
> collection      := sequence | mapping
> sequence        := SequenceStart node* SequenceEnd
> mapping         := MappingStart (node node)* MappingEnd
> node            := Alias | content
> 
> ?               => 0 or 1 of prefix
> *               => 0 or more of prefix
> +               => 1 or more of prefix
> ()              => production grouping
> |               => production logical OR
> ```

</details>

[`Parser`]: ./src/event/mod.rs
