### PR TITLE
Better separation between puiblic/private types in exported API

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -255,11 +255,11 @@ where
     /// for e in events.iter().filter_map(Result::ok)
     /// {
     ///     if let EventData::Scalar(Node {
-    ///         content: Scalar::Eager { data, .. },
+    ///         content: ScalarLike::Eager(scalar),
     ///         ..
     ///     }) = e.data()
     ///     {
-    ///         if let Ok(digit) = data.parse::<i32>()
+    ///         if let Ok(digit) = scalar.parse::<i32>()
     ///         {
     ///             println!("Got digit: {}", digit);
     ///         }

--- a/src/event/parser/macros.rs
+++ b/src/event/parser/macros.rs
@@ -111,7 +111,7 @@ macro_rules! state {
 macro_rules! consume {
     ($queue:expr, $kind:tt) => {{
         #[allow(unused_imports)]
-        use $crate::{token::Token::*, scanner::entry::MaybeToken, event::types::{Event, EventData, VersionDirective, Scalar}};
+        use $crate::{token::Token::*, scanner::entry::MaybeToken, event::types::{Event, EventData, VersionDirective, ScalarLike}};
 
         #[allow(clippy::collapsible_match)]
         pop!($queue).map(|entry| consume!(@wrap entry, $kind))
@@ -122,10 +122,10 @@ macro_rules! consume {
 
         match $entry.wrap {
             MaybeToken::Token(token) => match token {
-                Scalar(data, style) => (end, end, Scalar::Eager { data, style }),
+                Scalar(data, style) => (end, end, ScalarLike::eager(data, style)),
                 _ => unreachable!(),
             },
-            MaybeToken::Deferred(lazy) => (end, end, Scalar::Lazy { data: Box::new(lazy) })
+            MaybeToken::Deferred(lazy) => (end, end, ScalarLike::lazy(lazy))
         }
     }};
     (@wrap $entry:expr, $kind:tt) => {{

--- a/src/event/parser/tests/macros.rs
+++ b/src/event/parser/tests/macros.rs
@@ -200,10 +200,9 @@ macro_rules! scalar {
         }
     };
     ($content:expr, $style:expr) => {
-        types::Scalar::Eager {
-            data:  $crate::token::Slice::from($content),
-            style: $style,
-        }
+        types::ScalarLike::eager(
+            $crate::token::Slice::from($content), $style
+        )
     };
 }
 

--- a/src/event/types.rs
+++ b/src/event/types.rs
@@ -11,8 +11,10 @@ use std::{array::IntoIter as ArrayIter, borrow::Cow, collections::HashMap};
 
 use crate::{
     scanner::{entry::Lazy, error::ScanResult},
-    token::{ScalarStyle, Slice, StreamEncoding, Token},
+    token::Token,
 };
+
+pub type Slice<'a> = std::borrow::Cow<'a, str>;
 
 pub const DEFAULT_TAGS: [(Slice<'static>, Slice<'static>); 2] = [
     (Cow::Borrowed("!"), Cow::Borrowed("!")),
@@ -352,3 +354,19 @@ pub struct VersionDirective
 /// Typedef map of tag directives present in the current
 /// document
 pub type TagDirectives<'de> = HashMap<Slice<'de>, Slice<'de>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StreamEncoding
+{
+    UTF8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ScalarStyle
+{
+    Plain,
+    SingleQuote,
+    DoubleQuote,
+    Literal,
+    Folded,
+}

--- a/src/scanner/entry.rs
+++ b/src/scanner/entry.rs
@@ -20,15 +20,15 @@ use crate::{
 /// Note that this wrapper *does not* compare tokens, so if
 /// you desire that ensure that you compare them directly
 #[derive(Debug)]
-pub struct TokenEntry<'de>
+pub(crate) struct TokenEntry<'de>
 {
-    pub wrap: MaybeToken<'de>,
-    read_at:  usize,
+    pub(crate) wrap: MaybeToken<'de>,
+    read_at:         usize,
 }
 
 impl<'de> TokenEntry<'de>
 {
-    pub fn new<T>(token: T, read_at: usize) -> Self
+    pub(crate) fn new<T>(token: T, read_at: usize) -> Self
     where
         T: Into<MaybeToken<'de>>,
     {
@@ -38,22 +38,22 @@ impl<'de> TokenEntry<'de>
         }
     }
 
-    pub fn read_at(&self) -> usize
+    pub(crate) fn read_at(&self) -> usize
     {
         self.read_at
     }
 
-    pub fn marker(&self) -> Marker
+    pub(crate) fn marker(&self) -> Marker
     {
         self.wrap.marker()
     }
 
-    pub fn is_processed(&self) -> bool
+    pub(crate) fn is_processed(&self) -> bool
     {
         matches!(&self.wrap, MaybeToken::Token(_))
     }
 
-    pub fn into_token(self) -> Result<Token<'de>>
+    pub(crate) fn into_token(self) -> Result<Token<'de>>
     {
         self.wrap.into_token()
     }
@@ -86,7 +86,7 @@ impl<'de> Ord for TokenEntry<'de>
 }
 
 #[derive(Debug)]
-pub enum MaybeToken<'de>
+pub(crate) enum MaybeToken<'de>
 {
     Token(Token<'de>),
     Deferred(Lazy<'de>),
@@ -132,7 +132,7 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct Lazy<'de>
+pub(crate) struct Lazy<'de>
 {
     inner: LazyImpl<'de>,
 }

--- a/src/scanner/error.rs
+++ b/src/scanner/error.rs
@@ -131,3 +131,11 @@ impl From<ScanError> for ErrorCode
         }
     }
 }
+
+impl From<ScanError> for crate::error::Error
+{
+    fn from(err: ScanError) -> Self
+    {
+        crate::error::mkError!(err, CODE)
+    }
+}

--- a/src/scanner/error.rs
+++ b/src/scanner/error.rs
@@ -8,10 +8,10 @@ use std::fmt;
 
 use crate::error::internal::ErrorCode;
 
-pub type ScanResult<T> = std::result::Result<T, ScanError>;
+pub(crate) type ScanResult<T> = std::result::Result<T, ScanError>;
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum ScanError
+pub(crate) enum ScanError
 {
     /// Directive was not either YAML or TAG
     UnknownDirective,

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -41,7 +41,7 @@ use crate::{
 type Tokens<'de> = Queue<TokenEntry<'de>>;
 
 #[derive(Debug)]
-pub struct Scanner
+pub(crate) struct Scanner
 {
     /// Offset into the data buffer to start at
     offset: usize,

--- a/src/token.rs
+++ b/src/token.rs
@@ -4,7 +4,7 @@
  * was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-pub type Slice<'a> = std::borrow::Cow<'a, str>;
+pub use crate::event::types::{ScalarStyle, Slice, StreamEncoding};
 
 /// Tokens that may be emitted by a YAML scanner
 #[derive(Debug, PartialEq)]
@@ -198,20 +198,4 @@ impl PartialEq<Token<'_>> for Marker
     {
         self == &Self::from(other)
     }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum StreamEncoding
-{
-    UTF8,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum ScalarStyle
-{
-    Plain,
-    SingleQuote,
-    DoubleQuote,
-    Literal,
-    Folded,
 }


### PR DESCRIPTION
This PR should finally finish out the work to avoid private types appearing in the public API space.

Notably, some changes in `event/types` were made to obscure the private inner type, `lib/reader`'s `Read` trait was changed to take and return opaque types which do not leak private details, and many types were made explicitly private across the library.